### PR TITLE
Use secret NEOPETS_URL_ORIGIN to bypass HTTPS

### DIFF
--- a/app/models/neopets_user.rb
+++ b/app/models/neopets_user.rb
@@ -5,7 +5,8 @@ class NeopetsUser
   include ActiveModel::Conversion
   extend ActiveModel::Naming
 
-  GATEWAY_URL = 'http://www.neopets.com/amfphp/gateway.php'
+  NEOPETS_URL_ORIGIN = ENV['NEOPETS_URL_ORIGIN'] || 'http://www.neopets.com'
+  GATEWAY_URL = NEOPETS_URL_ORIGIN + '/amfphp/gateway.php'
   GET_PETS_METHOD = RocketAMF::RemoteGateway.new(GATEWAY_URL).
     service('MobileService').action('getPets')
 

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -2,7 +2,8 @@ require 'rocketamf/remote_gateway'
 require 'ostruct'
 
 class Pet < ActiveRecord::Base
-  GATEWAY_URL = 'http://www.neopets.com/amfphp/gateway.php'
+  NEOPETS_URL_ORIGIN = ENV['NEOPETS_URL_ORIGIN'] || 'http://www.neopets.com'
+  GATEWAY_URL = NEOPETS_URL_ORIGIN + '/amfphp/gateway.php'
   PET_VIEWER = RocketAMF::RemoteGateway.new(GATEWAY_URL).
     service('CustomPetService').action('getViewerData')
   PET_NOT_FOUND_REMOTE_ERROR = 'PHP: Unable to retrieve records from the database.'


### PR DESCRIPTION
Oops, neopets.com finally stopped accepting `http://` connections, so our AMFPHP requests stopped working! And our current dependencies make it hard to make modern HTTPS requests :(

Instead, we're doing this quick-fix: we have a connection who knows the internal address for the Neopets origin server behind their CDN, which *does* still accept `http://` requests!

So, when `NEOPETS_URL_ORIGIN` is specified in the secret `.env` file (not committed to the repository), we'll use it instead of `http://www.neopets.com`. However, we still have that in the code as a fallback, just to be a bit less surprising to some theoretical future dev so they can see the real error message, and to self-document a bit of what that value is semantically doing! (The documentation angle is more of why it's there, rather than an actual expectation that any actual person in the future will run the code and get the fallback.)