### PR TITLE
Oops, fix mall spider bug, added by our HTTPS fix

### DIFF
--- a/app/models/swf_asset.rb
+++ b/app/models/swf_asset.rb
@@ -11,6 +11,9 @@ class SwfAsset < ActiveRecord::Base
     'Cache-Control' => 'max-age=315360000',
     'Content-Type' => 'image/png'
   }
+  # This is the URL origin we should use when loading from images.neopets.com.
+  # It can be overridden in .env as `NEOPETS_IMAGES_URL_ORIGIN`, to use our
+  # asset proxy instead.
   NEOPETS_IMAGES_URL_ORIGIN = ENV['NEOPETS_IMAGES_URL_ORIGIN'] || 'http://images.neopets.com'
 
   set_inheritance_column 'inheritance_type'
@@ -248,7 +251,7 @@ class SwfAsset < ActiveRecord::Base
 
   def mall_data=(data)
     self.zone_id = data['zone'].to_i
-    self.url = "#{NEOPETS_IMAGES_URL_ORIGIN}/#{data['url']}"
+    self.url = "https://images.neopets.com/#{data['url']}"
   end
 
   def self.from_wardrobe_link_params(ids)


### PR DESCRIPTION
Oh, yeah, shit, okay, when we set `self.url` like that, it's supposed to be the _canonical_ URL for the SWF, not our proxied one—this is the URL that's gonna go in the database.

We do proxying late in the process, like when we're actually setting up to download something, but for just referencing where the asset lives, we use `images.neopets.com`.

In this change, we revert the use of `NEOPETS_IMAGES_URL_ORIGIN`, but we _do_ update this to `https` for good measure. (We currently have both HTTP and HTTPS urls in the database, I guess neopets.com started serving different URLs at some point, this is probably the future! And anything interpreting these URLs will need to handle both cases anyway, unless we do some kind of migration update situation thing.)

We're migrating the incorrect assets with the following query (with the limit changed to match the number we currently see in the DB, just as a safety check):
```
UPDATE swf_assets SET url = REPLACE(url, 'http://images.neopets-asset-proxy.openneo.net', 'https://images.neopets.com') WHERE url LIKE 'http://images.neopets-asset-proxy.openneo.net%' ORDER BY id LIMIT 2000;
```